### PR TITLE
Fix tooltip values after tiff reload

### DIFF
--- a/src/components/controls/ValueTooltipControl.tsx
+++ b/src/components/controls/ValueTooltipControl.tsx
@@ -166,7 +166,7 @@ const ValueTooltipControl: React.FC<ValueTooltipProps> = React.memo(({ categoryI
         tooltipRef.current = null;
       }
     };
-  }, [map, categoryId, layerId, dispatch]);
+  }, [map, categoryId, layerId, dispatch, layer?.metadata, valueRange]);
 
   return null;
 });


### PR DESCRIPTION
## Summary
- rerun value tooltip effect when layer metadata changes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*